### PR TITLE
Added check if image is already "dense" and fixed extension skipping

### DIFF
--- a/src/dense.js
+++ b/src/dense.js
@@ -150,7 +150,7 @@
             skipExtensions: ['svg']
         }, options);
 
-        var retina_suffix = options.glue + devicePixelRatio + 'x', regx = new RegExp(retina_suffix, "i");
+        var retina_suffix = options.glue + devicePixelRatio + 'x', regx = new RegExp(retina_suffix + "\.[a-zA-Z0-9]*", "i");
 
         this.each(function ()
         {


### PR DESCRIPTION
Added check if image is already "dense" (in case the name already ends
with “glue”+ devicePixelRatio + ‘x’), skip image with “no-dense” class
and fixed extension skipping as inArray returns 0 for SVG check, that
was evaluated to false and not skipped.
