### PR TITLE
Fix for issue #3.

### DIFF
--- a/src/dense.js
+++ b/src/dense.js
@@ -168,7 +168,7 @@
 
             if (!image)
             {
-                if (!originalImage || devicePixelRatio === 1 || $.inArray(originalImage.split('.').pop().split(/[\?\#]/).shift(), options.skipExtensions))
+                if (!originalImage || devicePixelRatio === 1 || $.inArray(originalImage.split('.').pop().split(/[\?\#]/).shift(), options.skipExtensions) !== -1)
                 {
                     $this.removeClass('dense-image dense-loading');
                     return;


### PR DESCRIPTION
Added the appropriate check to the code. Couldn't see any obvious way to test this since there doesn't appear to be a way to hardcode a devicePixelRatio.
